### PR TITLE
feat/error handling middleware and types

### DIFF
--- a/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
+++ b/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
@@ -1,0 +1,43 @@
+import APIError from '@src/errors/APIError';
+import { ExceptionMiddleware } from '@src/middlewares/ExceptionMiddleware';
+import { requestMock } from '@src/__mocks__/express/requestMock';
+import { responseMock } from '@src/__mocks__/express/responseMock';
+
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('13-06-2022'));
+});
+
+const exceptionMiddleware = new ExceptionMiddleware();
+
+describe('Exception Middleware', () => {
+  it('should return the APIError as a response if error is typeof APIError', async () => {
+    const apiErr = new APIError(400, 'Invalid data');
+    const next = jest.fn();
+
+    await exceptionMiddleware.execute(apiErr, requestMock, responseMock, next);
+
+    expect(responseMock.status).toHaveBeenCalledWith(400);
+    expect(responseMock.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'An error has occurred.',
+      data: apiErr
+    });
+  });
+
+  it('should return a defined response if the error raised isn\'t an APIError', async () => {
+    const apiErr = new Error('NullPointerException');
+    const next = jest.fn();
+
+    const definedError = new APIError(500, 'Server Internal Error, try again.');
+
+    await exceptionMiddleware.execute(apiErr, requestMock, responseMock, next);
+
+    expect(responseMock.status).toHaveBeenCalledWith(500);
+    expect(responseMock.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'An error has occurred.',
+      data: definedError
+    });
+  });
+});

--- a/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
+++ b/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
@@ -20,7 +20,7 @@ describe('Exception Middleware', () => {
     });
   });
 
-  it('should return a defined response if the error raised isn\'t an APIError', async () => {
+  it('should return a defined response if the error raised is not an APIError', async () => {
     const apiErr = new Error('NullPointerException');
 
     const definedError = new APIError(500, 'Server Internal Error, try again.');

--- a/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
+++ b/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
@@ -3,17 +3,12 @@ import { ExceptionMiddleware } from '@src/middlewares/ExceptionMiddleware';
 import { requestMock } from '@src/__mocks__/express/requestMock';
 import { responseMock } from '@src/__mocks__/express/responseMock';
 
-beforeAll(() => {
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date('13-06-2022'));
-});
-
 const exceptionMiddleware = new ExceptionMiddleware();
+const next = jest.fn();
 
 describe('Exception Middleware', () => {
   it('should return the APIError as a response if error is typeof APIError', async () => {
     const apiErr = new APIError(400, 'Invalid data');
-    const next = jest.fn();
 
     await exceptionMiddleware.execute(apiErr, requestMock, responseMock, next);
 
@@ -27,7 +22,6 @@ describe('Exception Middleware', () => {
 
   it('should return a defined response if the error raised isn\'t an APIError', async () => {
     const apiErr = new Error('NullPointerException');
-    const next = jest.fn();
 
     const definedError = new APIError(500, 'Server Internal Error, try again.');
 

--- a/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
+++ b/src/__tests__/unit/middlewares/ExceptionMiddleware.spec.ts
@@ -20,8 +20,8 @@ describe('Exception Middleware', () => {
     expect(responseMock.status).toHaveBeenCalledWith(400);
     expect(responseMock.json).toHaveBeenCalledWith({
       success: false,
-      message: 'An error has occurred.',
-      data: apiErr
+      message: apiErr.message,
+      data: null
     });
   });
 
@@ -36,8 +36,8 @@ describe('Exception Middleware', () => {
     expect(responseMock.status).toHaveBeenCalledWith(500);
     expect(responseMock.json).toHaveBeenCalledWith({
       success: false,
-      message: 'An error has occurred.',
-      data: definedError
+      message: definedError.message,
+      data: null
     });
   });
 });

--- a/src/__tests__/unit/modules/users/services/CreateUserService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/CreateUserService.spec.ts
@@ -3,6 +3,7 @@ import { UsersRepositoryMock } from '@mocks/modules/users/repositories/UsersRepo
 import { IUsersRepository } from '@src/modules/users/repositories/interfaces/IUsersRepository';
 import { CreateUserService } from '@src/modules/users/services/CreateUserService';
 import { ICreateUserService } from '@src/modules/users/services/interfaces/ICreateUserService';
+import APIError from '@src/errors/APIError';
 
 const usersRepository: IUsersRepository = new UsersRepositoryMock();
 const createUserService: ICreateUserService = new CreateUserService(
@@ -19,15 +20,16 @@ describe('CreateUserService', () => {
     expect(usersRepository.create).toHaveBeenCalledWith(usersMock[0]);
   });
 
-  it('should throw an error if user with provided email already exists', async () => {
+  it('should throw an APIError if user with provided email already exists', async () => {
     try {
       await createUserService.execute(usersMock[0]);
     } catch (error) {
-      expect((error as Error).message).toBe(
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).message).toBe(
         'User with provided email already exists.'
       );
     }
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 });

--- a/src/__tests__/unit/modules/users/services/CreateUserService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/CreateUserService.spec.ts
@@ -25,11 +25,12 @@ describe('CreateUserService', () => {
       await createUserService.execute(usersMock[0]);
     } catch (error) {
       expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(409);
       expect((error as APIError).message).toBe(
         'User with provided email already exists.'
       );
     }
 
-    expect.assertions(2);
+    expect.assertions(3);
   });
 });

--- a/src/__tests__/unit/modules/users/services/GetAllUsersService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/GetAllUsersService.spec.ts
@@ -2,6 +2,7 @@ import { usersMock } from '@mocks/modules/users/usersMocks';
 import { UsersRepositoryMock } from '@mocks/modules/users/repositories/UsersRepositoryMock';
 import { IUsersRepository } from '@src/modules/users/repositories/interfaces/IUsersRepository';
 import { GetAllUsersService } from '@src/modules/users/services/GetAllUsersService';
+import APIError from '@src/errors/APIError';
 
 const usersRepository: IUsersRepository = new UsersRepositoryMock();
 const getAllUsersService = new GetAllUsersService(usersRepository);
@@ -16,15 +17,16 @@ describe('GetAllUsersService', () => {
     expect(usersRepository.getAll).toHaveBeenCalledWith(1);
   });
 
-  it('should throw an error if no users are found', async () => {
+  it('should throw an APIError if no users are found', async () => {
     jest.spyOn(usersRepository, 'getAll').mockResolvedValue([]);
 
     try {
       await getAllUsersService.execute(1);
     } catch (error) {
-      expect((error as Error).message).toBe('No users found.');
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).message).toBe('No users found.');
     }
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 });

--- a/src/__tests__/unit/modules/users/services/GetAllUsersService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/GetAllUsersService.spec.ts
@@ -24,9 +24,10 @@ describe('GetAllUsersService', () => {
       await getAllUsersService.execute(1);
     } catch (error) {
       expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(204);
       expect((error as APIError).message).toBe('No users found.');
     }
 
-    expect.assertions(2);
+    expect.assertions(3);
   });
 });

--- a/src/__tests__/unit/modules/users/services/GetUserByIdService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/GetUserByIdService.spec.ts
@@ -3,6 +3,7 @@ import { UsersRepositoryMock } from '@mocks/modules/users/repositories/UsersRepo
 import { IUsersRepository } from '@src/modules/users/repositories/interfaces/IUsersRepository';
 import { GetUserByIdService } from '@src/modules/users/services/GetUserByIdService';
 import { IGetUserByIdService } from '@src/modules/users/services/interfaces/IGetUserByIdService';
+import APIError from '@src/errors/APIError';
 
 const usersRepository: IUsersRepository = new UsersRepositoryMock();
 const getUserByIdService: IGetUserByIdService = new GetUserByIdService(
@@ -21,17 +22,18 @@ describe('GetUserByIdService', () => {
     expect(usersRepository.getById).toHaveBeenCalledWith(usersMock[0].id);
   });
 
-  it('should throw an error if user is not found', async () => {
+  it('should throw an APIError if user is not found', async () => {
     jest.spyOn(usersRepository, 'getById').mockResolvedValue(null);
 
     try {
       await getUserByIdService.execute(usersMock[0].id as string);
     } catch (error) {
-      expect((error as Error).message).toBe(
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).message).toBe(
         'User with provided id does not exist.'
       );
     }
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 });

--- a/src/__tests__/unit/modules/users/services/GetUserByIdService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/GetUserByIdService.spec.ts
@@ -29,11 +29,12 @@ describe('GetUserByIdService', () => {
       await getUserByIdService.execute(usersMock[0].id as string);
     } catch (error) {
       expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(404);
       expect((error as APIError).message).toBe(
         'User with provided id does not exist.'
       );
     }
 
-    expect.assertions(2);
+    expect.assertions(3);
   });
 });

--- a/src/__tests__/unit/modules/users/services/RemoveUserService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/RemoveUserService.spec.ts
@@ -28,11 +28,12 @@ describe('GetUserByIdService', () => {
       await removeUserService.execute(usersMock[0].id as string);
     } catch (error) {
       expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(404);
       expect((error as APIError).message).toBe(
         'User with provided id does not exist.'
       );
     }
 
-    expect.assertions(2);
+    expect.assertions(3);
   });
 });

--- a/src/__tests__/unit/modules/users/services/RemoveUserService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/RemoveUserService.spec.ts
@@ -3,6 +3,7 @@ import { UsersRepositoryMock } from '@mocks/modules/users/repositories/UsersRepo
 import { IUsersRepository } from '@src/modules/users/repositories/interfaces/IUsersRepository';
 import { IRemoveUserService } from '@src/modules/users/services/interfaces/IRemoveUserService';
 import { RemoveUserService } from '@src/modules/users/services/RemoveUserService';
+import APIError from '@src/errors/APIError';
 
 const usersRepository: IUsersRepository = new UsersRepositoryMock();
 const removeUserService: IRemoveUserService = new RemoveUserService(
@@ -20,17 +21,18 @@ describe('GetUserByIdService', () => {
     expect(usersRepository.remove).toHaveBeenCalledWith(usersMock[0].id);
   });
 
-  it('should throw an error if user with provided id does not exist', async () => {
+  it('should throw an APIError if user with provided id does not exist', async () => {
     jest.spyOn(usersRepository, 'getById').mockResolvedValue(null);
 
     try {
       await removeUserService.execute(usersMock[0].id as string);
     } catch (error) {
-      expect((error as Error).message).toBe(
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).message).toBe(
         'User with provided id does not exist.'
       );
     }
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 });

--- a/src/__tests__/unit/modules/users/services/UpdateUserService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/UpdateUserService.spec.ts
@@ -30,12 +30,13 @@ describe('UpdateUserService', () => {
       await updateUserService.execute(usersMock[0]);
     } catch (error) {
       expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(404);
       expect((error as APIError).message).toBe(
         'User with provided id does not exist.'
       );
     }
 
-    expect.assertions(2);
+    expect.assertions(3);
   });
 
   it('should throw an APIError if a different user with provided email already exists', async () => {
@@ -46,11 +47,12 @@ describe('UpdateUserService', () => {
       await updateUserService.execute(usersMock[0]);
     } catch (error) {
       expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(409);
       expect((error as APIError).message).toBe(
         'User with provided email already exists.'
       );
     }
 
-    expect.assertions(2);
+    expect.assertions(3);
   });
 });

--- a/src/__tests__/unit/modules/users/services/UpdateUserService.spec.ts
+++ b/src/__tests__/unit/modules/users/services/UpdateUserService.spec.ts
@@ -3,6 +3,7 @@ import { UsersRepositoryMock } from '@mocks/modules/users/repositories/UsersRepo
 import { IUsersRepository } from '@src/modules/users/repositories/interfaces/IUsersRepository';
 import { IUpdateUserService } from '@src/modules/users/services/interfaces/IUpdateUserService';
 import { UpdateUserService } from '@src/modules/users/services/UpdateUserService';
+import APIError from '@src/errors/APIError';
 
 const usersRepository: IUsersRepository = new UsersRepositoryMock();
 const updateUserService: IUpdateUserService = new UpdateUserService(
@@ -22,32 +23,34 @@ describe('UpdateUserService', () => {
     expect(usersRepository.update).toHaveBeenCalled();
   });
 
-  it('should throw an error if user with provided id does not exist', async () => {
+  it('should throw an APIError if user with provided id does not exist', async () => {
     jest.spyOn(usersRepository, 'getById').mockResolvedValue(null);
 
     try {
       await updateUserService.execute(usersMock[0]);
     } catch (error) {
-      expect((error as Error).message).toBe(
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).message).toBe(
         'User with provided id does not exist.'
       );
     }
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 
-  it('should throw an error if a different user with provided email already exists', async () => {
+  it('should throw an APIError if a different user with provided email already exists', async () => {
     jest.spyOn(usersRepository, 'getById').mockResolvedValue(usersMock[0]);
     jest.spyOn(usersRepository, 'getByEmail').mockResolvedValue(usersMock[1]);
 
     try {
       await updateUserService.execute(usersMock[0]);
     } catch (error) {
-      expect((error as Error).message).toBe(
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).message).toBe(
         'User with provided email already exists.'
       );
     }
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 });

--- a/src/configs/app.ts
+++ b/src/configs/app.ts
@@ -7,6 +7,8 @@ import 'express-async-errors';
 import { UsersRouter } from '../routers/UsersRouter';
 import { AuthRouter } from '../routers/AuthRouter';
 import { PostsRouter } from '@src/routers/PostsRouter';
+import { ExceptionMiddleware } from '@src/middlewares/ExceptionMiddleware';
+const exceptionMiddleware = new ExceptionMiddleware();
 
 const app = express();
 
@@ -15,5 +17,7 @@ app.use(express.json());
 app.use(AuthRouter());
 app.use(UsersRouter());
 app.use(PostsRouter());
+
+app.use(exceptionMiddleware.execute);
 
 export default app;

--- a/src/middlewares/ExceptionMiddleware.ts
+++ b/src/middlewares/ExceptionMiddleware.ts
@@ -9,14 +9,20 @@ export class ExceptionMiddleware implements IErrorMiddleware {
     res: Response,
     _next: NextFunction
   ): Promise<Response> => {
-    if (!(err instanceof APIError)) {
-      err = new APIError(500, 'Server Internal Error, try again.');
+    let returnedError: APIError;
+
+    if (err instanceof APIError) {
+      returnedError = err;
+    } else {
+      returnedError = new APIError(500, 'Server Internal Error, try again.');
     }
 
-    return res.status(err.status).json({
+    console.error(err);
+
+    return res.status(returnedError.status).json({
       success: false,
-      message: 'An error has occurred.',
-      data: err
+      message: returnedError.message,
+      data: null
     });
   };
 }

--- a/src/middlewares/ExceptionMiddleware.ts
+++ b/src/middlewares/ExceptionMiddleware.ts
@@ -4,7 +4,7 @@ import APIError from '../errors/APIError';
 
 export class ExceptionMiddleware implements IErrorMiddleware {
   execute = async (
-    err: APIError,
+    err: Error,
     _req: Request,
     res: Response,
     _next: NextFunction

--- a/src/middlewares/ExceptionMiddleware.ts
+++ b/src/middlewares/ExceptionMiddleware.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+
+import APIError from '../errors/APIError';
+
+export class ExceptionMiddleware implements IErrorMiddleware {
+  execute = async (
+    err: APIError,
+    _req: Request,
+    res: Response,
+    _next: NextFunction
+  ): Promise<Response> => {
+    if (!(err instanceof APIError)) {
+      err = new APIError(500, 'Server Internal Error, try again.');
+    }
+
+    return res.status(err.status).json({
+      success: false,
+      message: 'An error has occurred.',
+      data: err
+    });
+  };
+}

--- a/src/modules/users/services/CreateUserService.ts
+++ b/src/modules/users/services/CreateUserService.ts
@@ -1,3 +1,4 @@
+import APIError from '@src/errors/APIError';
 import { IUser } from '../interfaces/IUser';
 import { IUsersRepository } from '../repositories/interfaces/IUsersRepository';
 import { ICreateUserService } from './interfaces/ICreateUserService';
@@ -13,7 +14,7 @@ export class CreateUserService implements ICreateUserService {
     const existentUser = await this.#usersRepository.getByEmail(data.email);
 
     if (existentUser)
-      throw new Error('User with provided email already exists.');
+      throw new APIError(409, 'User with provided email already exists.');
 
     await this.#usersRepository.create(data);
   };

--- a/src/modules/users/services/GetAllUsersService.ts
+++ b/src/modules/users/services/GetAllUsersService.ts
@@ -1,3 +1,4 @@
+import APIError from '@src/errors/APIError';
 import { IUser } from '../interfaces/IUser';
 import { IUsersRepository } from '../repositories/interfaces/IUsersRepository';
 import { IGetAllUsersService } from './interfaces/IGetAllUsersService';
@@ -12,7 +13,7 @@ export class GetAllUsersService implements IGetAllUsersService {
   execute = async (page: number): Promise<IUser[]> => {
     const users = await this.#usersRepository.getAll(page);
 
-    if (users.length <= 0) throw new Error('No users found.');
+    if (users.length <= 0) throw new APIError(204, 'No users found.');
 
     return users;
   };

--- a/src/modules/users/services/GetUserByIdService.ts
+++ b/src/modules/users/services/GetUserByIdService.ts
@@ -1,3 +1,4 @@
+import APIError from '@src/errors/APIError';
 import { IUser } from '../interfaces/IUser';
 import { IUsersRepository } from '../repositories/interfaces/IUsersRepository';
 import { IGetUserByIdService } from './interfaces/IGetUserByIdService';
@@ -12,7 +13,8 @@ export class GetUserByIdService implements IGetUserByIdService {
   execute = async (id: string): Promise<IUser> => {
     const existentUser = await this.#usersRepository.getById(id);
 
-    if (!existentUser) throw new Error('User with provided id does not exist.');
+    if (!existentUser)
+      throw new APIError(404, 'User with provided id does not exist.');
 
     return existentUser;
   };

--- a/src/modules/users/services/RemoveUserService.ts
+++ b/src/modules/users/services/RemoveUserService.ts
@@ -1,3 +1,4 @@
+import APIError from '@src/errors/APIError';
 import { IUsersRepository } from '../repositories/interfaces/IUsersRepository';
 import { IRemoveUserService } from './interfaces/IRemoveUserService';
 
@@ -11,7 +12,8 @@ export class RemoveUserService implements IRemoveUserService {
   execute = async (id: string): Promise<void> => {
     const existentUser = await this.#usersRepository.getById(id);
 
-    if (!existentUser) throw new Error('User with provided id does not exist.');
+    if (!existentUser)
+      throw new APIError(404, 'User with provided id does not exist.');
 
     await this.#usersRepository.remove(id);
   };

--- a/src/modules/users/services/UpdateUserService.ts
+++ b/src/modules/users/services/UpdateUserService.ts
@@ -1,3 +1,4 @@
+import APIError from '@src/errors/APIError';
 import { IUser } from '../interfaces/IUser';
 import { IUsersRepository } from '../repositories/interfaces/IUsersRepository';
 import { IUpdateUserService } from './interfaces/IUpdateUserService';
@@ -12,12 +13,13 @@ export class UpdateUserService implements IUpdateUserService {
   execute = async (data: IUser): Promise<void> => {
     const existentUser = await this.#usersRepository.getById(data.id as string);
 
-    if (!existentUser) throw new Error('User with provided id does not exist.');
+    if (!existentUser)
+      throw new APIError(404, 'User with provided id does not exist.');
 
     const userWithEmail = await this.#usersRepository.getByEmail(data.email);
 
     if (userWithEmail && userWithEmail.id !== data.id)
-      throw new Error('User with provided email already exists.');
+      throw new APIError(409, 'User with provided email already exists.');
 
     await this.#usersRepository.update(data);
   };

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -28,7 +28,7 @@ declare global {
 
   interface IErrorMiddleware extends IMiddleware {
     execute: (
-      err: APIError,
+      err: Error,
       req: Request,
       res: IResponse,
       next: NextFunction

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,3 +1,4 @@
+import APIError from '@src/errors/APIError';
 import { Request, Response, NextFunction } from 'express';
 import { Send } from 'express-serve-static-core';
 
@@ -23,5 +24,14 @@ declare global {
       res: IResponse,
       next: NextFunction
     ) => Promise<void>;
+  }
+
+  interface IErrorMiddleware extends IMiddleware {
+    execute: (
+      err: APIError,
+      req: Request,
+      res: IResponse,
+      next: NextFunction
+    ) => Promise<Response>;
   }
 }


### PR DESCRIPTION
# Description

To improve error handling better, an exception middleware was made and attached to the end of express middleware chain.
The middleware follows this rule: 

- if an APIError is raised, send the error content in the defined response pattern (message + status)
- else, send a defined error with 500 status code and server internal error message

Fixes #6 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) 
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Raise an Exception in any service by passing invalid data
- Force a Error exception to show the 500 error message

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules